### PR TITLE
New web features - API endpoints and /metrics Prometheus #1066

### DIFF
--- a/Software/src/devboard/webserver/api/api_status_html.cpp
+++ b/Software/src/devboard/webserver/api/api_status_html.cpp
@@ -127,7 +127,7 @@ String api_status_processor() {
 #endif
 
   addJsonBool(json, "battery_allows_contactor_closing", datalayer.system.status.battery_allows_contactor_closing);
-  addJsonBool(json, "inverter_allows_contactor_closing", datalayer.system.status.inverter_allows_contactor_closing);
+  addJsonBool(json, "inverter_allows_contactor_closing", datalayer.system.status.inverter_allows_contactor_closing, false);
 
   json += "}";
 

--- a/Software/src/devboard/webserver/metrics_html.cpp
+++ b/Software/src/devboard/webserver/metrics_html.cpp
@@ -142,7 +142,8 @@ String metrics_html_processor() {
   // Contactor information
   output += "be_battery_contactor_status{" + deviceLabel + "} " +
             String(datalayer.system.status.contactors_engaged ? 1 : 0) + "\n";
-  else output += "be_battery_contactor_status{" + deviceLabel + "} " + "1" + "\n";
+#else 
+  output += "be_battery_contactor_status{" + deviceLabel + "} " + "1" + "\n";
 #endif
 
   output += "be_battery_allows_contactor_closing{" + deviceLabel + "} " +

--- a/Software/src/devboard/webserver/metrics_html.cpp
+++ b/Software/src/devboard/webserver/metrics_html.cpp
@@ -142,7 +142,7 @@ String metrics_html_processor() {
   // Contactor information
   output += "be_battery_contactor_status{" + deviceLabel + "} " +
             String(datalayer.system.status.contactors_engaged ? 1 : 0) + "\n";
-#else 
+#else
   output += "be_battery_contactor_status{" + deviceLabel + "} " + "1" + "\n";
 #endif
 


### PR DESCRIPTION
What
This PR implements simple API READ endpoints
and /metrics for Prometheus - https://prometheus.io/docs/introduction/overview/

Why
Why does it do it?
Extending the functionality of BE

How
How does it do it?
#define API_ENDPOINTS //When enabled, json API endpoints are available
and
#define PROMETHEUS_METRICS //When enabled, /metrics will be available for Prometheus scraping

How to use it:
/api/status - Status of the BE
/api/cell - cells voltages
/api/events - events in json format
/api/full - full info combined (to reduce load if full info is required)

$ curl --silent http://192.168.22.104/api/status | jq 
{
  "system": {
    "version": "8.11.dev",
    "uptime": "0d 0h 10m 46s",
    "inverter_protocol": "Pylontech battery over CAN bus",
    "inverter_brand": "",
    "battery_protocol": "Kia/Hyundai EGMP platform",
    "temperature": 41.11,
    "emulator_status": "RUNNING",
    "equipment_stop": false,
    "led_status": "GREEN"
  },
  "battery": {
    "soc_real": 67,
    "soc_reported": 67,
    "soc_scaling_active": false,
    "soh": 100,
    "voltage": 728.8,
    "current": 0,
    "power": 0,
    "capacity_total_wh": 77100,
    "capacity_reported_wh": 77000,
    "capacity_remaining_wh": 51657,
    "capacity_reported_remaining_wh": 51657,
    "max_discharge_power": 21000,
    "max_charge_power": 21000,
    "max_discharge_current": 25,
    "max_charge_current": 25,
    "user_settings_limit_discharge": true,
    "user_settings_limit_charge": true,
    "inverter_limits_discharge": true,
    "inverter_limits_charge": true,
    "cell_min_voltage": 3760,
    "cell_max_voltage": 3800,
    "cell_delta": 40,
    "cell_delta_limit": 150,
    "temp_min": 18,
    "temp_max": 20,
    "bms_status": 3,
    "bms_status_text": "ACTIVE",
    "contactor_status": true,
    "battery_allows_contactor_closing": true,
    "inverter_allows_contactor_closing": true
  }
}

/metrics - Prometheus-ready endpoint fof scraping the data

Tested!

Additional info:
Cost:
with API: Sketch uses 1202168 bytes (61%)
without: Sketch uses 1193116 bytes (60%)

Once merged, i will write a wiki documentation